### PR TITLE
Changed layout to use dropdowns, bugfixes.

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -36,3 +36,12 @@ ignore_users = ["bernardinocampos", "marcopaganini", "mpinheir", "qrwteyrutiyoup
 
   [points.desafio-09]
   value = 30
+
+  [points.desafio-10]
+  value = 60
+
+  [points.desafio-11]
+  value = 60
+
+  [points.desafio-12]
+  value = 30

--- a/templates/scoreboard.template
+++ b/templates/scoreboard.template
@@ -27,29 +27,33 @@ mesmo que a resolução do desafio permaneça no repositório.
 {{ range . }}
 {{ if .FirstInGroup }}
 <div class="row">
-<h2>{{ .Rank }}ª posição: {{ .Score.Points }} pontos</h2>
+  <div class="col-md-12">
+    <h2>{{ .Rank }}ª posição: {{ .Score.Points }} pontos</h2>
+  </div>
 {{ end }}
+<div class="col-md-3" style="text-align:center; margin-bottom: 20px;">
+  <!-- Username and Avatar. Avatar must be size limited since image sizes vary. -->
+  <a href="https://github.com/{{ .GithubUser }}">
+    <img style="width:150px; height:150px; margin-bottom:10px;" src="{{ .GithubInfo.AvatarURL }}" alt="{{ .GithubUser }}">
+  </a>
 
-<div class="col-md-4" style="margin-bottom: 20px;">
-  <table>
-  <td style="vertical-align: top;">
-    <a href="https://github.com/{{ .GithubUser }}">
-    <img style="width:150px;height:150px;" src="{{ .GithubInfo.AvatarURL }}" alt="{{ .GithubUser }}">
-    </a>
-  </td>
-  <td style="vertical-align: top; padding-left: 8px;">
-    <h3 style="margin-top: 0px;">{{ .GithubUser }}</h3>
-    {{ $GithubUser := .GithubUser }}
-    {{ range .Score.Completed }}
-      <p style="margin-bottom: 2px;">
-      <a href="https://github.com//OsProgramadores/op-desafios/tree/master/{{ .Name }}/{{ $GithubUser }}">
-      &#x2605; {{ .Name }}
-      </a>
-      &nbsp;<span style="font-style:italic; font-size:80%">(+{{ .Points }})</span>
-      </p>
-    {{ end }}
-  </td>
-  </table>
+  <!-- Button -->
+  <div class="dropdown">
+    <button type="button" id="button-{{ .GithubUser }}" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+      {{ .GithubUser }}<span class="caret"></span>
+    </button>
+
+    <ul class="dropdown-menu" aria-labelledby="button-{{ .GithubUser }}" style="width:100px;">
+      {{ $GithubUser := .GithubUser }}
+      {{ range .Score.Completed }}
+      <li><a href="https://github.com//OsProgramadores/op-desafios/tree/master/{{ .Name }}/{{ $GithubUser }}">
+        {{ .Name }}
+        <span style="font-style:italic; font-size:80%">(+{{ .Points }})</span>
+        </a>
+      </li>
+      {{ end }}
+    </ul>
+  </div>
 </div>
 
 {{ if .LastInGroup }}


### PR DESCRIPTION
Changes:

b4a71e4 (Marco Paganini, 30 seconds ago)
   Change layout to use Dropdowns.

   With the number of desafios increasing, we need a better way to see them on
   the screen. Remove the default output and replace it by a dropdown 
   containing the user name. Also, lots of formatting improvements (removed 
   the table, made things a bit tighter, etc).

   Note: Attempted to put six pictures on a row, but that created problems 
   with devices having 992 pixel widths, since we use col-md-* for rows and 
   github usernames can get creatively long. :)

dc8d03c (Marco Paganini, 3 minutes ago)
   Bugfix: Don't re-fetch negative cache entries.

   Split readFromNegativeCache outside readFromCache. This allows us to not
   attempt a github fetch (eating quota) for deleted users.

0f78f85 (Marco Paganini, 5 minutes ago)
   Update config.toml to include desafios-{10..12}

   This is *not* the production config, just a sample in the repo itself. This
   was updated to allow the use of the real op-desafios for testing purposes.

Note:
   Do not squash this change! Just rebase on github!