### PR TITLE
Add support for auth token. Remove cache code.

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"errors"
-	"github.com/BurntSushi/toml"
 	"io"
 	"io/ioutil"
+
+	"github.com/BurntSushi/toml"
 )
 
 // Point holds the points required for a challenge.

--- a/config/config.toml
+++ b/config/config.toml
@@ -45,3 +45,9 @@ ignore_users = ["bernardinocampos", "marcopaganini", "mpinheir", "qrwteyrutiyoup
 
   [points.desafio-12]
   value = 30
+
+  [points.desafio-13]
+  value = 50
+
+  [points.desafio-14]
+  value = 40

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/osprogramadores/op-scoreboard
 
 go 1.18
 
-require github.com/BurntSushi/toml v1.2.0
+require (
+	github.com/BurntSushi/toml v1.2.0
+	github.com/cenkalti/backoff/v4 v4.1.3
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/BurntSushi/toml v1.2.0 h1:Rt8g24XnyGTyglgET/PRUNlrUeu9F5L+7FilkXfZgs0=
 github.com/BurntSushi/toml v1.2.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
+github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=


### PR DESCRIPTION
- Add support for authentication tokens. This allows the use of
  op-scoreboard without the need to keep state (authentication
  gives a higher quota in the github API.)
- Remove the (now unnecessary) caching code.
- Update the configuration file with missing items.
