### PR TITLE
Count obsolete challenges as zero points

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -19,9 +19,10 @@ ignore_users = ["bernardinocampos", "marcopaganini", "mpinheir", "qrwteyrutiyoup
   [points.desafio-03]
   value = 20
 
+  # The challenges 4 and 5 are obsolete so they do not count as points
   [points.desafio-04]
-  value = 20
-
+  value = 0
+  
   [points.desafio-05]
   value = 50
 

--- a/config/config.toml
+++ b/config/config.toml
@@ -22,9 +22,9 @@ ignore_users = ["bernardinocampos", "marcopaganini", "mpinheir", "qrwteyrutiyoup
   # The challenges 4 and 5 are obsolete so they do not count as points
   [points.desafio-04]
   value = 0
-  
+
   [points.desafio-05]
-  value = 50
+  value = 0
 
   [points.desafio-06]
   value = 70


### PR DESCRIPTION
It will not count the obsolete challenges anymore when building the hi-score rankings.